### PR TITLE
update settings modal styles to match theme

### DIFF
--- a/packages/react-app/src/components/Contract/index.jsx
+++ b/packages/react-app/src/components/Contract/index.jsx
@@ -173,8 +173,12 @@ export default function Contract({
             </p>
             <p>They will be appended to the URL so you can share it.</p>
             <div style={{ display: "flex", gap: "10px", marginBottom: 10 }}>
-              <Button onClick={() => setSeletectedContractMethods(allMethodsNames)}>Select all</Button>
-              <Button onClick={() => setSeletectedContractMethods([])}>Remove all</Button>
+              <Button className="method-selection-button" onClick={() => setSeletectedContractMethods(allMethodsNames)}>
+                Select all
+              </Button>
+              <Button className="method-selection-button" onClick={() => setSeletectedContractMethods([])}>
+                Remove all
+              </Button>
             </div>
             <Checkbox.Group options={allMethodsNames} value={seletectedContractMethods} onChange={handleMethodChange} />
           </Modal>

--- a/packages/react-app/src/styles/_contract.less
+++ b/packages/react-app/src/styles/_contract.less
@@ -50,9 +50,8 @@ body.path-contract {
 }
 
 .method-selection {
-
   // modal close button
-  .ant-modal-close{
+  .ant-modal-close {
     &:hover {
       color: @primary-color;
     }
@@ -62,12 +61,12 @@ body.path-contract {
     background-color: @almost-white;
     border-radius: 5px;
 
-    .ant-modal-header{
+    .ant-modal-header {
       background-color: @almost-white;
       border-color: @primary-color;
       border-radius: 5px 5px 0 0;
 
-      .ant-modal-title{
+      .ant-modal-title {
         color : @primary-color;
       }
     }
@@ -79,12 +78,10 @@ body.path-contract {
         border-color: @primary-color;
         color: @primary-color;
         background-color: transparent;
-        // background-color: @medium-color;
         padding: 5px 20px;
         border-radius: 8px;
         font-weight: 500;
         &:hover {
-          // background-color: @ligthdark-color;
           background-color: @medium-color;
         }
       }
@@ -101,7 +98,6 @@ body.path-contract {
     .ant-checkbox-input:focus+.ant-checkbox-inner {
       border-color: @primary-color !important;
     }
-
   }
 
   .ant-checkbox-group {

--- a/packages/react-app/src/styles/_contract.less
+++ b/packages/react-app/src/styles/_contract.less
@@ -50,6 +50,60 @@ body.path-contract {
 }
 
 .method-selection {
+
+  // modal close button
+  .ant-modal-close{
+    &:hover {
+      color: @primary-color;
+    }
+  }
+
+  .ant-modal-content {
+    background-color: @almost-white;
+    border-radius: 5px;
+
+    .ant-modal-header{
+      background-color: @almost-white;
+      border-color: @primary-color;
+      border-radius: 5px 5px 0 0;
+
+      .ant-modal-title{
+        color : @primary-color;
+      }
+    }
+
+    .ant-modal-body { 
+      color : @primary-color;
+
+      .method-selection-button {
+        border-color: @primary-color;
+        color: @primary-color;
+        background-color: transparent;
+        // background-color: @medium-color;
+        padding: 5px 20px;
+        border-radius: 8px;
+        font-weight: 500;
+        &:hover {
+          // background-color: @ligthdark-color;
+          background-color: @medium-color;
+        }
+      }
+    }
+
+    // Customizing default antD checkbox
+    .ant-checkbox-checked .ant-checkbox-inner {
+      background-color: @primary-color;
+      border-color: @primary-color;
+    }
+  
+    .ant-checkbox-wrapper:hover .ant-checkbox-inner,
+    .ant-checkbox:hover .ant-checkbox-inner,
+    .ant-checkbox-input:focus+.ant-checkbox-inner {
+      border-color: @primary-color !important;
+    }
+
+  }
+
   .ant-checkbox-group {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Thanks so much for making such an awesome tool !! 

I noticed that the styling for Settings Modal looks different than the whole theme of the app, just updated it to match the overall theme. 

Before         |  After
:-----------:|:-------------------------------------------------------:
![Screenshot 2022-10-23 at 12 08 33 AM](https://user-images.githubusercontent.com/80153681/197357390-232c1c6f-2168-4439-aac6-2f80e96bcd15.jpg) | ![Screenshot 2022-10-23 at 12 08 23 AM](https://user-images.githubusercontent.com/80153681/197357395-d0ea380b-92fa-4c49-96d3-5ee3ee6bcdd8.jpg)

### Demo Video : 

https://user-images.githubusercontent.com/80153681/197357562-17309c11-7022-4169-9372-495e48c40342.mp4

please let me know if there are any changes or if something can be improved, be it css `class` naming convention or nesting of styles in `_contract.less` anything would love to improve it  🙌
