### PR TITLE
fix: transpile RainbowKit packages for Vercel compatibility

### DIFF
--- a/packages/nextjs/next.config.mjs
+++ b/packages/nextjs/next.config.mjs
@@ -11,6 +11,12 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
+  transpilePackages: [
+    "@rainbow-me/rainbowkit",
+    "@vanilla-extract/css",
+    "@vanilla-extract/dynamic",
+    "@vanilla-extract/sprinkles",
+  ],
   webpack: config => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     return config;


### PR DESCRIPTION
his PR fixes a CommonJS/ESM module compatibility issue that causes RainbowKit to fail on Vercel's serverless environment.  
                                                                                                                              
  The Problem:                                                                                                                
  - The contract page works fine on localhost but crashes on Vercel with: SyntaxError: Named export 'createMapValueFn' not    
  found                                                                                                                       
  - RainbowKit depends on @vanilla-extract/sprinkles which uses CommonJS, but RainbowKit tries to import named exports from it
   using ESM syntax                                                                                                           
  - Vercel's serverless Node.js environment is stricter about mixed module formats than local development                     
                                                                                                                              
  The Solution:                                                                                                               
  - Added transpilePackages to next.config.mjs to transpile RainbowKit and vanilla-extract packages during the build          
  - This allows Next.js to properly handle the module format conversion before deployment                                     
                                                                                                                              
  Technical Details:                                                                                                          
  - Next.js 13.1+ supports transpilePackages which transpiles specified packages from node_modules                            
  - This ensures all module formats are normalized during the build process                                                   
  - The fix specifically transpiles: @rainbow-me/rainbowkit, @vanilla-extract/css, @vanilla-extract/dynamic, and              
  @vanilla-extract/sprinkles                                                                                                  
                                                                                                                              
  Impact:                                                                                                                     
  - Fixes contract pages failing to load on Vercel production/preview deployments                                             
  - No changes to functionality or behavior, only build configuration                                                         
  - Zero impact on localhost development                                   