### PR TITLE
feat: show realistic example values in contract input placeholders

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractInput.tsx
@@ -12,6 +12,45 @@ import {
 } from "~~/components/scaffold-eth";
 import { AbiParameterTuple } from "~~/utils/scaffold-eth/contract";
 
+const getPlaceholderExample = (type: string): string => {
+  if (type.includes("[")) {
+    const baseType = type.replace(/\[\d*\]$/, "");
+    const baseExample = getPlaceholderExample(baseType);
+    return `[${baseExample}, ...]`;
+  }
+
+  switch (type) {
+    case "address":
+      return "vitalik.eth or 0xd8dA...6045";
+    case "bool":
+      return "true";
+    case "string":
+      return "Hello World";
+    case "bytes":
+      return "0x00";
+    case "bytes32":
+      return "0x0000...0000";
+  }
+
+  if (type.startsWith("uint")) {
+    const bits = parseInt(type.slice(4)) || 256;
+    if (bits <= 8) return "42";
+    return "1000";
+  }
+
+  if (type.startsWith("int")) {
+    const bits = parseInt(type.slice(3)) || 256;
+    if (bits <= 8) return "-42";
+    return "-1000";
+  }
+
+  if (type.startsWith("bytes")) {
+    return "0x00...00";
+  }
+
+  return type;
+};
+
 type ContractInputProps = {
   setForm: Dispatch<SetStateAction<Record<string, any>>>;
   form: Record<string, any> | undefined;
@@ -26,7 +65,7 @@ export const ContractInput = ({ setForm, form, stateObjectKey, paramType }: Cont
   const inputProps = {
     name: stateObjectKey,
     value: form?.[stateObjectKey],
-    placeholder: paramType.type,
+    placeholder: getPlaceholderExample(paramType.type),
     onChange: (value: any) => {
       setForm(form => ({ ...form, [stateObjectKey]: value }));
     },


### PR DESCRIPTION
## What

Replaces the literal Solidity type name in every contract input placeholder with a concrete, realistic example for that type.

| Type | Before | After |
| --- | --- | --- |
| `address` | `address` | `vitalik.eth or 0xd8dA...6045` |
| `bool` | `bool` | `true` |
| `string` | `string` | `Hello World` |
| `bytes` | `bytes` | `0x00` |
| `bytes32` | `bytes32` | `0x0000...0000` |
| `bytesN` (N > 0) | `bytesN` | `0x00...00` |
| `uintN` (N ≤ 8) | `uintN` | `42` |
| `uintN` (N > 8) | `uintN` | `1000` |
| `intN` (N ≤ 8) | `intN` | `-42` |
| `intN` (N > 8) | `intN` | `-1000` |
| `T[]` / `T[N]` | `T[]` | `[<example for T>, ...]` (recursive) |

The Solidity type itself is still shown above the input as the small label (`paramType.type`), so power users don't lose any information — the placeholder just becomes useful instead of redundant.

## Why

The placeholder currently echoes the type name (`packages/nextjs/components/scaffold-eth/Contract/ContractInput.tsx:29` on `main`), which is the same string already rendered above the input as the type label. That gives newcomers zero hint about the expected input format and makes the field look unnecessarily intimidating.

Showing a real example value tells a first-time user immediately:
- `address` accepts ENS names, not just hex
- numeric inputs aren't padded / decimal-separated
- arrays use square-bracket JSON syntax
- bytes inputs are hex with the `0x` prefix

This is one of the highest leverage UX changes possible: a single input component is reused by every read and write method across every contract on every chain.

## How

Adds a pure helper `getPlaceholderExample(type)` to `ContractInput.tsx` and uses it for the `placeholder` prop. Array types recurse on the base type so nested types like `uint256[][]` produce `[[1000, ...], ...]`.

## Risk

Visual-only change inside the input `placeholder` attribute. No behavior, no validation, no submission logic touched. No new dependencies.